### PR TITLE
Update required by BOIPA for 12th August 2015 11am

### DIFF
--- a/src/Omnipay/Evo/Message/PurchaseRequest.php
+++ b/src/Omnipay/Evo/Message/PurchaseRequest.php
@@ -19,7 +19,7 @@ class PurchaseRequest extends AbstractRequest
     protected $liveRedirectUrl = 'https://pay.boipa.com/fim/paymentgate';
     protected $testRedirectUrl = 'https://testvpos.boipa.com/fim/paymentgate';
     
-    protected $liveMerchantType = 'pay_hosting';
+    protected $liveMerchantType = '3d_pay_hosting';
     protected $testMerchantType = '3d_pay_hosting';
     
     public function getMerchantId()


### PR DESCRIPTION
## Email from BOIPA

We are in the process of making changes on our e-Comm platform in regards to taking payments. In order to increase security and reduce fraudulent payments on your web site we are introduction an extra security layer with 3D secure.

We will be making the switch on our server on the 12th August at 11 am. We estimate that it would cause a max downtime  of 10 minutes. Someone at DigiTickets will be need to be ready to change the code to reflect 3D secure.

Code will need to be changed from:
StoreType= pay_hosting
to:  StoreType= 3d_pay_hosting
