### PR TITLE
Allow the use of OmniPay standard setReturnUrl

### DIFF
--- a/src/Omnipay/Evo/Message/PurchaseRequest.php
+++ b/src/Omnipay/Evo/Message/PurchaseRequest.php
@@ -52,6 +52,13 @@ class PurchaseRequest extends AbstractRequest
     public function getMerchantType() {
         return $this->getTestMode() ? $this->testMerchantType : $this->liveMerchantType;
     }
+    
+    public function setReturnUrl($value)
+    {
+        $this->setOkUrl($value);
+        $this->setFailUrl($value);
+        $this->setPendingUrl($value);
+    }
 
     public function setOkUrl($value) {
         return $this->setParameter('okUrl', $value);


### PR DESCRIPTION
Useful for systems where all types of callback are handled by a standard endpoint.
